### PR TITLE
Adds tokengated storefront example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Hydrogen is Shopify's open source stack for headless commerce.
 ## Examples
 
 - [Hydrogen NodeJS Express Example](https://github.com/Shopify/hydrogen/tree/2023-04/examples/express)
+- [Tokengated Storefront Example](https://github.com/Shopify/gated-hydrogen-example)
 
 ## Apps & Integrations
 


### PR DESCRIPTION
Adding the Tokengated Storefront Example to the examples here for future reference.

Originally, I was planning on adding the example to the Hydrogen repo via https://github.com/Shopify/hydrogen/pull/1079, but given that the example makes use of `unstable` to utilize `Gates` it doesn't make sense to add the example to the stable-release versions of Hydrogen.